### PR TITLE
Propagate trace context to called lambda

### DIFF
--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/build.gradle.kts
@@ -12,6 +12,7 @@ muzzle {
     extraDependency("software.amazon.awssdk:protocol-core")
     excludeInstrumentationName("aws-sdk-2.2-sqs")
     excludeInstrumentationName("aws-sdk-2.2-sns")
+    excludeInstrumentationName("aws-sdk-2.2-lambda")
 
     // several software.amazon.awssdk artifacts are missing for this version
     skip("2.17.200")
@@ -42,6 +43,7 @@ muzzle {
     extraDependency("software.amazon.awssdk:protocol-core")
 
     excludeInstrumentationName("aws-sdk-2.2-sns")
+    excludeInstrumentationName("aws-sdk-2.2-lambda")
 
     // several software.amazon.awssdk artifacts are missing for this version
     skip("2.17.200")
@@ -56,6 +58,22 @@ muzzle {
     extraDependency("software.amazon.awssdk:protocol-core")
 
     excludeInstrumentationName("aws-sdk-2.2-sqs")
+    excludeInstrumentationName("aws-sdk-2.2-lambda")
+
+    // several software.amazon.awssdk artifacts are missing for this version
+    skip("2.17.200")
+  }
+
+  pass {
+    group.set("software.amazon.awssdk")
+    module.set("lambda")
+    versions.set("[2.2.0,)")
+    // Used by all SDK services, the only case it isn't is an SDK extension such as a custom HTTP
+    // client, which is not target of instrumentation anyways.
+    extraDependency("software.amazon.awssdk:protocol-core")
+
+    excludeInstrumentationName("aws-sdk-2.2-sqs")
+    excludeInstrumentationName("aws-sdk-2.2-sns")
 
     // several software.amazon.awssdk artifacts are missing for this version
     skip("2.17.200")
@@ -82,6 +100,7 @@ dependencies {
   testLibrary("software.amazon.awssdk:sqs:2.2.0")
   testLibrary("software.amazon.awssdk:sns:2.2.0")
   testLibrary("software.amazon.awssdk:ses:2.2.0")
+  testLibrary("software.amazon.awssdk:lambda:2.2.0")
 }
 
 tasks {

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAdviceBridge.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAdviceBridge.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2;
+
+public final class LambdaAdviceBridge {
+  private LambdaAdviceBridge() {}
+
+  public static void referenceForMuzzleOnly() {
+    throw new UnsupportedOperationException(
+        LambdaImpl.class.getName() + " referencing for muzzle, should never be actually called");
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/LambdaInstrumentationModule.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/javaagent/src/main/java/io/opentelemetry/javaagent/instrumentation/awssdk/v2_2/LambdaInstrumentationModule.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.javaagent.instrumentation.awssdk.v2_2;
+
+import com.google.auto.service.AutoService;
+import io.opentelemetry.instrumentation.awssdk.v2_2.LambdaAdviceBridge;
+import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
+import io.opentelemetry.javaagent.extension.instrumentation.TypeTransformer;
+import net.bytebuddy.asm.Advice;
+
+import static net.bytebuddy.matcher.ElementMatchers.none;
+
+@AutoService(InstrumentationModule.class)
+public class LambdaInstrumentationModule extends AbstractAwsSdkInstrumentationModule {
+
+  public LambdaInstrumentationModule() {
+    super("aws-sdk-2.2-lambda");
+  }
+
+  @Override
+  public boolean isHelperClass(String className) {
+    return super.isHelperClass(className)
+        || className.startsWith("com.fasterxml.jackson.")
+        || className.startsWith("org.w3c.dom."); // Jackson references it somewhere
+  }
+
+  @Override
+  public void doTransform(TypeTransformer transformer) {
+    transformer.applyAdviceToMethod(
+        none(), LambdaInstrumentationModule.class.getName() + "$RegisterAdvice");
+  }
+
+  @SuppressWarnings("unused")
+  public static class RegisterAdvice {
+    @Advice.OnMethodExit(suppress = Throwable.class)
+    public static void onExit() {
+      // (indirectly) using LambdaImpl class here to make sure it is available from LambdaAccess
+      // (injected into app classloader) and checked by Muzzle
+      LambdaAdviceBridge.referenceForMuzzleOnly();
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/build.gradle.kts
@@ -4,10 +4,12 @@ plugins {
 
 dependencies {
   implementation("io.opentelemetry.contrib:opentelemetry-aws-xray-propagator")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.15.2")
 
   library("software.amazon.awssdk:aws-core:2.2.0")
   library("software.amazon.awssdk:sqs:2.2.0")
   library("software.amazon.awssdk:sns:2.2.0")
+  library("software.amazon.awssdk:lambda:2.2.0")
   library("software.amazon.awssdk:aws-json-protocol:2.2.0")
   compileOnly(project(":muzzle")) // For @NoMuzzle
 

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAccess.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
+import software.amazon.awssdk.core.SdkRequest;
+import javax.annotation.Nullable;
+
+final class LambdaAccess {
+  private LambdaAccess() {}
+
+  private static final boolean enabled = PluginImplUtil.isImplPresent("LambdaImpl");
+
+  @Nullable
+  @NoMuzzle
+  public static SdkRequest modifyRequest(
+      SdkRequest request, Context otelContext, TextMapPropagator messagingPropagator) {
+    System.out.println("LambdaAccess.modifyRequest: enabled: "+ enabled);
+    return enabled ? LambdaImpl.modifyRequest(request, otelContext, messagingPropagator) : null;
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAccess.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaAccess.java
@@ -8,8 +8,8 @@ package io.opentelemetry.instrumentation.awssdk.v2_2;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.javaagent.tooling.muzzle.NoMuzzle;
-import software.amazon.awssdk.core.SdkRequest;
 import javax.annotation.Nullable;
+import software.amazon.awssdk.core.SdkRequest;
 
 final class LambdaAccess {
   private LambdaAccess() {}
@@ -20,7 +20,6 @@ final class LambdaAccess {
   @NoMuzzle
   public static SdkRequest modifyRequest(
       SdkRequest request, Context otelContext, TextMapPropagator messagingPropagator) {
-    System.out.println("LambdaAccess.modifyRequest: enabled: "+ enabled);
     return enabled ? LambdaImpl.modifyRequest(request, otelContext, messagingPropagator) : null;
   }
 }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.awssdk.v2_2;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+
+// this class is only used from LambdaAccess from method with @NoMuzzle annotation
+final class LambdaImpl {
+
+  private static final Logger logger = LoggerFactory.getLogger(LambdaImpl.class);
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  static {
+    // Force loading of LambdaClient; this ensures that an exception is thrown at this point when the
+    // Lambda library is not present, which will cause LambdaAccess to have enabled=false in library mode.
+    @SuppressWarnings("unused")
+    String ensureLoadedDummy = LambdaClient.class.getName();
+  }
+
+  private LambdaImpl() {}
+
+  @Nullable
+  static SdkRequest modifyRequest(
+      SdkRequest request, Context otelContext, TextMapPropagator messagingPropagator) {
+    System.out.println(
+        "LambdaImpl.modifyRequest " + request.getClass().getCanonicalName() + " from "
+            + request.getClass().getClassLoader() + "messagingPropagator" + messagingPropagator);
+
+    if (messagingPropagator == null) {
+      return null;
+    }
+
+    if (request instanceof InvokeRequest) {
+      System.out.println("injectIntoInvokeRequest");
+      return injectIntoInvokeRequest((InvokeRequest) request, otelContext, messagingPropagator);
+    } else {
+      return null;
+    }
+  }
+
+  private static SdkRequest injectIntoInvokeRequest(
+      InvokeRequest request, Context otelContext, TextMapPropagator messagingPropagator) {
+    String modifiedClientContext = injectIntoClientContext(request.clientContext(), otelContext,
+        messagingPropagator);
+    return request.toBuilder().clientContext(modifiedClientContext).build();
+  }
+
+  private static String injectIntoClientContext(
+      String originalClientContext,
+      Context otelContext,
+      TextMapPropagator messagingPropagator) {
+
+    try {
+      Map<String, Object> clientContext = deserialiseClientContext(originalClientContext);
+      if (clientContext == null) {
+        clientContext = new HashMap<>();
+      }
+
+      Object customObject = clientContext.computeIfAbsent("custom",
+          k -> new HashMap<String, String>());
+      if (!(customObject instanceof Map)) {
+        return originalClientContext;
+      }
+
+      @SuppressWarnings("unchecked")
+      Map<String, String> custom = (Map<String, String>) customObject;
+      messagingPropagator.inject(
+          otelContext,
+          custom,
+          MapSetter.INSTANCE
+      );
+      String modifiedClientContext = serialiseClientContext(clientContext);
+      // Make sure we don't exceed the size limit imposed by AWS https://docs.aws.amazon.com/lambda/latest/dg/API_Invoke.html
+      if (modifiedClientContext.length() <= 3583) {
+        return modifiedClientContext;
+      } else {
+        return originalClientContext;
+      }
+    } catch (Throwable e) {
+      logger.warn("Failed to inject trace context into client context", e);
+      // Whenever something goes wrong we fall back to using the original clientContext
+      return originalClientContext;
+    }
+  }
+
+  @Nullable
+  private static Map<String, Object> deserialiseClientContext(String base64ClientContext)
+      throws Exception {
+    try {
+      if (base64ClientContext == null) {
+        return null;
+      } else {
+        String json = new String(Base64.getDecoder().decode(base64ClientContext), UTF_8);
+        TypeReference<HashMap<String, Object>> typeRef
+            = new TypeReference<HashMap<String, Object>>() {};
+        return OBJECT_MAPPER.readValue(json, typeRef);
+      }
+    } catch (Throwable e) {
+      throw new Exception("Failed to deserialize client context \"" + base64ClientContext + "\"",
+          e);
+    }
+  }
+
+  private static String serialiseClientContext(Map<String, Object> context)
+      throws Exception {
+    try {
+      String jsonString = OBJECT_MAPPER.writeValueAsString(context);
+      return Base64.getEncoder().encodeToString(jsonString.getBytes(UTF_8));
+    } catch (Throwable e) {
+      throw new Exception("Failed to serialise client context " + context, e);
+    }
+  }
+
+  private enum MapSetter implements TextMapSetter<Map<String, String>> {
+    INSTANCE;
+
+    @Override
+    public void set(Map<String, String> carrier, String key, String value) {
+      carrier.put(key, value);
+    }
+  }
+}

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaImpl.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/LambdaImpl.java
@@ -5,8 +5,6 @@
 
 package io.opentelemetry.instrumentation.awssdk.v2_2;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.opentelemetry.context.Context;
@@ -41,16 +39,11 @@ final class LambdaImpl {
   @Nullable
   static SdkRequest modifyRequest(
       SdkRequest request, Context otelContext, TextMapPropagator messagingPropagator) {
-    System.out.println(
-        "LambdaImpl.modifyRequest " + request.getClass().getCanonicalName() + " from "
-            + request.getClass().getClassLoader() + "messagingPropagator" + messagingPropagator);
-
     if (messagingPropagator == null) {
       return null;
     }
 
     if (request instanceof InvokeRequest) {
-      System.out.println("injectIntoInvokeRequest");
       return injectIntoInvokeRequest((InvokeRequest) request, otelContext, messagingPropagator);
     } else {
       return null;
@@ -109,7 +102,7 @@ final class LambdaImpl {
       if (base64ClientContext == null) {
         return null;
       } else {
-        String json = new String(Base64.getDecoder().decode(base64ClientContext), UTF_8);
+        byte[] json = Base64.getDecoder().decode(base64ClientContext);
         TypeReference<HashMap<String, Object>> typeRef
             = new TypeReference<HashMap<String, Object>>() {};
         return OBJECT_MAPPER.readValue(json, typeRef);
@@ -123,8 +116,8 @@ final class LambdaImpl {
   private static String serialiseClientContext(Map<String, Object> context)
       throws Exception {
     try {
-      String jsonString = OBJECT_MAPPER.writeValueAsString(context);
-      return Base64.getEncoder().encodeToString(jsonString.getBytes(UTF_8));
+      byte[] json = OBJECT_MAPPER.writeValueAsBytes(context);
+      return Base64.getEncoder().encodeToString(json);
     } catch (Throwable e) {
       throw new Exception("Failed to serialise client context " + context, e);
     }

--- a/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
+++ b/instrumentation/aws-sdk/aws-sdk-2.2/library/src/main/java/io/opentelemetry/instrumentation/awssdk/v2_2/TracingExecutionInterceptor.java
@@ -130,6 +130,10 @@ final class TracingExecutionInterceptor implements ExecutionInterceptor {
     if (modifiedRequest != null) {
       return modifiedRequest;
     }
+    modifiedRequest = LambdaAccess.modifyRequest(request, otelContext, messagingPropagator);
+    if (modifiedRequest != null) {
+      return modifiedRequest;
+    }
 
     // Insert other special handling here, following the same pattern as SQS and SNS.
 


### PR DESCRIPTION
This is based on a similar solution already present for SNS except here we need to deal with parsing/serializing the `clientContext` for which we need `jackson`.