### PR TITLE
Require aws-lambda-java-events 3.3.1

### DIFF
--- a/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/Triggers.java
+++ b/instrumentation/aws-lambda/aws-lambda-core-1.0/library/src/main/java/io/opentelemetry/instrumentation/awslambdacore/v1_0/internal/Triggers.java
@@ -31,8 +31,6 @@ public class Triggers {
 
   public Instrumenter<AwsLambdaRequest, Object> getInstrumenterForRequest(
       AwsLambdaRequest request) {
-    System.out.println("Input Class: " + request.getInput().getClass());
-    System.out.println("Input: " + request.getInput());
     for (int i = 0; i < triggers.length; i++) {
       if (triggers[i].matches(request)) {
         return instrumenters[i];

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/build.gradle.kts
@@ -7,13 +7,13 @@ muzzle {
     group.set("com.amazonaws")
     module.set("aws-lambda-java-core")
     versions.set("[1.0.0,)")
-    extraDependency("com.amazonaws:aws-lambda-java-events:3.4.0")
+    extraDependency("com.amazonaws:aws-lambda-java-events:3.3.1")
     extraDependency("com.amazonaws.serverless:aws-serverless-java-container-core:1.5.2")
   }
   pass {
     group.set("com.amazonaws")
     module.set("aws-lambda-java-events")
-    versions.set("[3.4.0,)")
+    versions.set("[3.3.1,)")
     extraDependency("com.amazonaws.serverless:aws-serverless-java-container-core:1.5.2")
   }
 }
@@ -29,7 +29,7 @@ dependencies {
   }
 
   library("com.amazonaws:aws-lambda-java-core:1.0.0")
-  library("com.amazonaws:aws-lambda-java-events:3.4.0")
+  library("com.amazonaws:aws-lambda-java-events:3.3.1")
 
   testImplementation(project(":instrumentation:aws-lambda:aws-lambda-events-2.2:testing"))
   testInstrumentation(project(":instrumentation:aws-lambda:aws-lambda-core-1.0:javaagent"))

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/javaagent/build.gradle.kts
@@ -7,7 +7,13 @@ muzzle {
     group.set("com.amazonaws")
     module.set("aws-lambda-java-core")
     versions.set("[1.0.0,)")
-    extraDependency("com.amazonaws:aws-lambda-java-events:2.2.1")
+    extraDependency("com.amazonaws:aws-lambda-java-events:3.4.0")
+    extraDependency("com.amazonaws.serverless:aws-serverless-java-container-core:1.5.2")
+  }
+  pass {
+    group.set("com.amazonaws")
+    module.set("aws-lambda-java-events")
+    versions.set("[3.4.0,)")
     extraDependency("com.amazonaws.serverless:aws-serverless-java-container-core:1.5.2")
   }
 }
@@ -23,11 +29,7 @@ dependencies {
   }
 
   library("com.amazonaws:aws-lambda-java-core:1.0.0")
-  // First version to includes support for SQSEvent, currently the most popular message queue used
-  // with lambda.
-  // NB: 2.2.0 includes a class called SQSEvent but isn't usable due to it returning private classes
-  // in public API.
-  library("com.amazonaws:aws-lambda-java-events:2.2.1")
+  library("com.amazonaws:aws-lambda-java-events:3.4.0")
 
   testImplementation(project(":instrumentation:aws-lambda:aws-lambda-events-2.2:testing"))
   testInstrumentation(project(":instrumentation:aws-lambda:aws-lambda-core-1.0:javaagent"))

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/build.gradle.kts
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
   // allows to get the function ARN
   testLibrary("com.amazonaws:aws-lambda-java-core:1.2.1")
   // allows to get the default events
-  testLibrary("com.amazonaws:aws-lambda-java-events:3.10.0")
+  testLibrary("com.amazonaws:aws-lambda-java-events:3.3.1")
 
   testImplementation("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
   testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators")

--- a/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/triggers/SqsTrigger.java
+++ b/instrumentation/aws-lambda/aws-lambda-events-2.2/library/src/main/java/io/opentelemetry/instrumentation/awslambdaevents/v2_2/internal/triggers/SqsTrigger.java
@@ -93,6 +93,9 @@ public final class SqsTrigger extends Trigger {
 
     @Override
     public String get(Map<String, SQSEvent.MessageAttribute> map, String s) {
+      if (map == null) {
+        return null;
+      }
       SQSEvent.MessageAttribute attribute = map.get(s.toLowerCase(Locale.ROOT));
       if (attribute == null) {
         return null;
@@ -142,9 +145,13 @@ public final class SqsTrigger extends Trigger {
     }
 
     String arn = event.getRecords().get(0).getEventSourceArn();
+    if (arn == null) {
+      return Optional.empty();
+    }
     for (int i = 1; i < event.getRecords().size(); i++) {
       SQSMessage message = event.getRecords().get(i);
-      if (!message.getEventSourceArn().equals(arn)) {
+      String messageArn = message.getEventSourceArn();
+      if (messageArn == null || !message.getEventSourceArn().equals(arn)) {
         return Optional.empty();
       }
     }


### PR DESCRIPTION
This is the first version that contains all the events we handle as triggers. These changes fix muzzle tests (tests that check if the instrumentation will work with different versions of instrumented libraries). This PR also fixes null pointer in unit tests.